### PR TITLE
Update to config blockHandler

### DIFF
--- a/lib/pxconfig.js
+++ b/lib/pxconfig.js
@@ -148,7 +148,7 @@ class PxConfig {
         }
 
         /* handling block handler overriding */
-        if (userInput === 'blockHandler' || userInput === 'getUserIp' || userInput === 'additionalActivityHandler' || userInput === 'customRequestHandler') {
+        if (userInput === 'getUserIp' || userInput === 'additionalActivityHandler' || userInput === 'customRequestHandler') {
             if (typeof params[userInput] === 'function') {
                 return params[userInput];
             }

--- a/lib/pxenforcer.js
+++ b/lib/pxenforcer.js
@@ -119,6 +119,9 @@ class PxEnforcer {
                 response.status = '403';
                 response.statusDescription = "Forbidden";
 
+                response.block_score = pxCtx.score;
+                response.block_uuid = pxCtx.uuid;
+
                 if (pxCtx.cookieOrigin == "cookie") {
                     response.header = {key: 'Content-Type', value:'text/html'};
                     response.body = htmlTemplate;


### PR DESCRIPTION
This pull removes blockHandler from the config options and adds `block_score` and `block_uuid` to the response returned, in order to match the blockHandler as outlined in the perimeterx-node-express README.

It will close #19 in conjunction with [pull 53](https://github.com/PerimeterX/perimeterx-node-express/pull/53) from the perimeterx-node-express.