### PR TITLE
Feature/sensitive graphql

### DIFF
--- a/lib/enums/GraphqlOperationType.js
+++ b/lib/enums/GraphqlOperationType.js
@@ -1,0 +1,8 @@
+const GraphqlOperationType = {
+    QUERY: 'query',
+    MUTATION: 'mutation'
+};
+
+module.exports = {
+    GraphqlOperationType
+};

--- a/lib/models/GraphqlData.js
+++ b/lib/models/GraphqlData.js
@@ -1,0 +1,10 @@
+class GraphqlData {
+    constructor(graphqlOperationType, graphqlOperationName) {
+        this.operationType = graphqlOperationType;
+        this.operationName = graphqlOperationName;
+    }
+}
+
+module.exports = {
+    GraphqlData
+};

--- a/lib/pxapi.js
+++ b/lib/pxapi.js
@@ -60,6 +60,11 @@ function buildRequestData(ctx, config) {
         },
     };
 
+    if (ctx.graphqlData) {
+        data.additional['graphql_operation_type'] = ctx.graphqlData.operationType;
+        data.additional['graphql_operation_name'] = ctx.graphqlData.operationName;
+    }
+
     if (ctx.s2sCallReason === 'cookie_decryption_failed') {
         data.additional.px_orig_cookie = ctx.getCookie(); //No need strigify, already a string
     }

--- a/lib/pxconfig.js
+++ b/lib/pxconfig.js
@@ -77,6 +77,8 @@ class PxConfig {
             ['LOGIN_CREDS_EXTRACTION', 'px_login_credentials_extraction'],
             ['COMPROMISED_CREDENTIALS_HEADER', 'px_compromised_credentials_header'],
             ['ENABLE_ADDITIONAL_ACTIVITY_HEADER', 'px_additional_activity_header_enabled'],
+            ['SENSITIVE_GRAPHQL_OPERATION_TYPES', 'px_sensitive_graphql_operation_types'],
+            ['SENSITIVE_GRAPHQL_OPERATION_NAMES', 'px_sensitive_graphql_operation_names'],
         ];
 
         configKeyMapping.forEach(([targetKey, sourceKey]) => {
@@ -316,6 +318,8 @@ function pxDefaultConfig() {
         LOGIN_CREDS_EXTRACTION: [],
         COMPROMISED_CREDENTIALS_HEADER: DEFAULT_COMPROMISED_CREDENTIALS_HEADER_NAME,
         ENABLE_ADDITIONAL_ACTIVITY_HEADER: false,
+        SENSITIVE_GRAPHQL_OPERATION_TYPES: [],
+        SENSITIVE_GRAPHQL_OPERATION_NAMES: []
     };
 }
 
@@ -364,6 +368,8 @@ const allowedConfigKeys = [
     'px_login_credentials_extraction_enabled',
     'px_login_credentials_extraction',
     'px_compromised_credentials_header',
+    'px_sensitive_graphql_operation_types',
+    'px_sensitive_graphql_operation_names'
 ];
 
 module.exports = PxConfig;

--- a/lib/pxcontext.js
+++ b/lib/pxcontext.js
@@ -55,7 +55,7 @@ class PxContext {
         if (this.uri.includes('graphql')) {
             config.logger.debug('Graphql route detected');
             this.graphqlData = pxUtil.getGraphqlData(req);
-            this.sensitiveGraphqlOperation = this.isSensitiveGraphqlOperation(config, this.graphqlData);
+            this.sensitiveGraphqlOperation = this.isSensitiveGraphqlOperation(config);
         }
     }
 
@@ -74,12 +74,11 @@ class PxContext {
         return Array.isArray(routes) ? routes.some((route) => this.verifyRoute(route, uri)) : false;
     }
 
-    isSensitiveGraphqlOperation(config, graphqlData) {
-        if (!graphqlData) {
+    isSensitiveGraphqlOperation(config) {
+        if (!this.graphqlData) {
             return false;
         }
-
-        const { operationType, operationName } = graphqlData;
+        const { operationType, operationName } = this.graphqlData;
         return config.SENSITIVE_GRAPHQL_OPERATION_TYPES.includes(operationType)
             || config.SENSITIVE_GRAPHQL_OPERATION_NAMES.includes(operationName);
     }

--- a/lib/pxcontext.js
+++ b/lib/pxcontext.js
@@ -53,6 +53,7 @@ class PxContext {
             });
         }
         if (this.uri.includes('graphql')) {
+            config.logger.debug('Graphql route detected');
             this.graphqlData = pxUtil.getGraphqlData(req);
             this.sensitiveGraphqlOperation = this.isSensitiveGraphqlOperation(config, this.graphqlData);
         }

--- a/lib/pxcontext.js
+++ b/lib/pxcontext.js
@@ -52,6 +52,10 @@ class PxContext {
                 }
             });
         }
+        if (this.uri.includes('graphql')) {
+            this.graphqlData = pxUtil.getGraphqlData(req);
+            this.sensitiveGraphqlOperation = this.isSensitiveGraphqlOperation(config, this.graphqlData);
+        }
     }
 
     getCookie() {
@@ -67,6 +71,16 @@ class PxContext {
      */
     isSpecialRoute(routes, uri) {
         return Array.isArray(routes) ? routes.some((route) => this.verifyRoute(route, uri)) : false;
+    }
+
+    isSensitiveGraphqlOperation(config, graphqlData) {
+        if (!graphqlData) {
+            return false;
+        }
+
+        const { operationType, operationName } = graphqlData;
+        return config.SENSITIVE_GRAPHQL_OPERATION_TYPES.includes(operationType)
+            || config.SENSITIVE_GRAPHQL_OPERATION_NAMES.includes(operationName);
     }
 
     verifyRoute(pattern, uri) {

--- a/lib/pxcookie.js
+++ b/lib/pxcookie.js
@@ -86,6 +86,12 @@ function evalCookie(ctx, config) {
             return ScoreEvaluateAction.SENSITIVE_ROUTE;
         }
 
+        if (ctx.sensitiveGraphqlOperation) {
+            config.logger.debug(`Sensitive graphql operation, sending Risk API. operation type: ${ctx.graphqlData.graphqlOperationType}, operation name: ${ctx.graphqlData.graphqlOperationName}`);
+            ctx.s2sCallReason = 'sensitive_route';
+            return ScoreEvaluateAction.SENSITIVE_ROUTE;
+        }
+
         ctx.passReason = PassReason.COOKIE;
         config.logger.debug(`Cookie evaluation ended successfully, risk score: ${cookie.getScore()}`);
         return ScoreEvaluateAction.GOOD_SCORE;

--- a/lib/pxcookie.js
+++ b/lib/pxcookie.js
@@ -87,7 +87,7 @@ function evalCookie(ctx, config) {
         }
 
         if (ctx.sensitiveGraphqlOperation) {
-            config.logger.debug(`Sensitive graphql operation, sending Risk API. operation type: ${ctx.graphqlData.graphqlOperationType}, operation name: ${ctx.graphqlData.graphqlOperationName}`);
+            config.logger.debug(`Sensitive graphql operation, sending Risk API. operation type: ${ctx.graphqlData.operationType}, operation name: ${ctx.graphqlData.operationName}`);
             ctx.s2sCallReason = 'sensitive_route';
             return ScoreEvaluateAction.SENSITIVE_ROUTE;
         }

--- a/lib/pxutil.js
+++ b/lib/pxutil.js
@@ -5,6 +5,8 @@ const fs = require('fs');
 const crypto = require('crypto');
 
 const { ModuleMode } = require('./enums/ModuleMode');
+const { GraphqlOperationType } = require('./enums/GraphqlOperationType');
+const { GraphqlData } = require('./models/GraphqlData');
 
 /**
  * PerimeterX (http://www.perimeterx.com) NodeJS-Express SDK
@@ -264,6 +266,29 @@ function getTokenObject(cookie, delimiter = ':') {
     return { key: '_px3', value: cookie };
 }
 
+function getGraphqlData(req) {
+    if (!req.fullUrl.includes('graphql')) {
+        return null;
+    }
+
+    const queryArray = req.body['query'] ? req.body['query'].split(/[^A-Za-z0-9_]/) : null;
+    if (!queryArray || queryArray.length < 1) {
+        return new GraphqlData(GraphqlOperationType.QUERY);
+    }
+
+    let operationType = queryArray[0];
+    let operationName = queryArray[1];
+    if (!Object.keys(GraphqlOperationType).includes(operationType)) {
+        operationType = GraphqlOperationType.QUERY;
+        operationName = queryArray[0];
+    }
+    if (req.body['operationName']) {
+        operationName = req.body['operationName'];
+    }
+
+    return new GraphqlData(operationType, operationName);
+}
+
 module.exports = {
     formatHeaders,
     filterSensitiveHeaders,
@@ -282,4 +307,5 @@ module.exports = {
     generateHMAC,
     isReqInMonitorMode,
     getTokenObject,
+    getGraphqlData
 };

--- a/lib/pxutil.js
+++ b/lib/pxutil.js
@@ -267,26 +267,42 @@ function getTokenObject(cookie, delimiter = ':') {
 }
 
 function getGraphqlData(req) {
-    if (!req.path.includes('graphql')) {
+    const isGraphqlPath = req.path.includes('graphql') || req.originalUrl.includes('graphql');
+    if (!isGraphqlPath) {
         return null;
     }
 
-    const queryArray = req.body['query'] ? req.body['query'].split(/[^A-Za-z0-9_]/) : null;
-    if (!queryArray || queryArray.length < 1) {
+    const query = req.body ? req.body['query'] : null;
+    if (!query) {
         return new GraphqlData(GraphqlOperationType.QUERY);
     }
 
-    let operationType = queryArray[0];
-    let operationName = queryArray[1];
-    if (!Object.values(GraphqlOperationType).includes(operationType)) {
-        operationType = GraphqlOperationType.QUERY;
-        operationName = queryArray[0];
-    }
-    if (req.body['operationName']) {
-        operationName = req.body['operationName'];
+    const operationType = extractGraphqlOperationType(query);
+    const operationName = extractGraphqlOperationName(query, req.body['operationName'])
+    return new GraphqlData(operationType, operationName);
+}
+
+function extractGraphqlOperationType(query) {
+    const isGraphqlQueryShorthand = query[0] === '{';
+    if (isGraphqlQueryShorthand) {
+        return GraphqlOperationType.QUERY;
     }
 
-    return new GraphqlData(operationType, operationName);
+    const queryArray = query.split(/[^A-Za-z0-9_]/);
+    return isValidGraphqlOperationType(queryArray[0]) ? queryArray[0] : GraphqlOperationType.QUERY;
+}
+
+function extractGraphqlOperationName(query, operationName) {
+    if (operationName) {
+        return operationName;
+    }
+
+    const queryArray = query.split(/[^A-Za-z0-9_]/);
+    return isValidGraphqlOperationType(queryArray[0]) ? queryArray[1] : queryArray[0];
+}
+
+function isValidGraphqlOperationType(operationType) {
+    return Object.values(GraphqlOperationType).includes(operationType);
 }
 
 module.exports = {

--- a/lib/pxutil.js
+++ b/lib/pxutil.js
@@ -267,7 +267,7 @@ function getTokenObject(cookie, delimiter = ':') {
 }
 
 function getGraphqlData(req) {
-    if (!req.fullUrl.includes('graphql')) {
+    if (!req.path.includes('graphql')) {
         return null;
     }
 
@@ -278,7 +278,7 @@ function getGraphqlData(req) {
 
     let operationType = queryArray[0];
     let operationName = queryArray[1];
-    if (!Object.keys(GraphqlOperationType).includes(operationType)) {
+    if (!Object.values(GraphqlOperationType).includes(operationType)) {
         operationType = GraphqlOperationType.QUERY;
         operationName = queryArray[0];
     }

--- a/test/pxutils.test.js
+++ b/test/pxutils.test.js
@@ -45,6 +45,19 @@ describe('PX Utils - pxutils.js', () => {
         return done();
     });
 
+    it('should extract graphql data from the request body properly', () => {
+        const GRAPHQL_OPERATION_NAME = 'OperationName';
+        const GRAPHQL_OPERATION_TYPE = 'mutation';
+        const req = {
+            path: '/some/path/with/graphql',
+            body: {
+                query: `${GRAPHQL_OPERATION_TYPE} ${GRAPHQL_OPERATION_NAME} {\n    __typename\n}`
+            }
+        }
+        const graphqlData = pxutil.getGraphqlData(req);
+        graphqlData.operationType.should.be.exactly(GRAPHQL_OPERATION_TYPE);
+        graphqlData.operationName.should.be.exactly(GRAPHQL_OPERATION_NAME);
+    });
 });
 
 function px_enrich_custom_parameters(params, origReq) {


### PR DESCRIPTION
This feature has two parts:
(1) allowing a customer to configure sensitive graphql operation types or operation names
(2) sending the operation type and name on the risk_api activity

https://perimeterx.atlassian.net/browse/SDKNEW-1443