### PR TITLE
empty payload handling in pxhttpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.11.1] - 2023-12-10
+
+### Added
+
+- `failOnEmptyBody` flag for `callServer` to specify wether or not a request should fail if it has no body.
+
 ## [3.11.0] - 2023-05-16
 
 ### Changed

--- a/lib/pxclient.js
+++ b/lib/pxclient.js
@@ -165,7 +165,15 @@ class PxClient {
     }
 
     callServer(data, path, additionalHeaders, config, cb) {
-        pxHttpc.callServer(data, this.createHeaders(config, additionalHeaders), path, 'activities', config);
+        pxHttpc.callServer(
+            data,
+            this.createHeaders(config, additionalHeaders),
+            path,
+            'activities',
+            config,
+            null,
+            false,
+        );
         if (cb) {
             cb();
         }

--- a/lib/pxhttpc.js
+++ b/lib/pxhttpc.js
@@ -37,7 +37,12 @@ function callServer(data, headers, uri, callType, config, callback) {
                 if (err.toString().toLowerCase().includes('timeout')) {
                     return callback('timeout');
                 } else {
-                    return handleError(callback, S2SErrorReason.UNKNOWN_ERROR, `encountered error with risk api call: ${err}`, response);
+                    return handleError(
+                        callback,
+                        S2SErrorReason.UNKNOWN_ERROR,
+                        `encountered error with risk api call: ${err}`,
+                        response,
+                    );
                 }
             }
 
@@ -46,7 +51,7 @@ function callServer(data, headers, uri, callType, config, callback) {
                     callback,
                     S2SErrorReason.UNKNOWN_ERROR,
                     `call to perimeterx server returned null or empty response: ${response}`,
-                    response
+                    response,
                 );
             }
 
@@ -65,20 +70,35 @@ function callServer(data, headers, uri, callType, config, callback) {
 const handleOkResponse = (callback, response) => {
     let data = getDataFromResponse(response);
 
-    if (!data) {
-        return handleError(callback, S2SErrorReason.INVALID_RESPONSE, `unable to get data from response body: ${response.body}`, response);
+    if (!data && response.statusCode >= 300) {
+        return handleError(
+            callback,
+            S2SErrorReason.INVALID_RESPONSE,
+            `unable to get data from response body: ${response.body}`,
+            response,
+        );
     }
 
     if (typeof data !== 'object') {
         try {
             data = JSON.parse(data);
         } catch (e) {
-            return handleError(callback, S2SErrorReason.INVALID_RESPONSE, `error parsing response body - ${data}: ${e}`, response);
+            return handleError(
+                callback,
+                S2SErrorReason.INVALID_RESPONSE,
+                `error parsing response body - ${data}: ${e}`,
+                response,
+            );
         }
     }
 
-    if (data.status && data.status !== 0) {
-        return handleError((err) => callback(err, data), S2SErrorReason.REQUEST_FAILED_ON_SERVER, data.message, response);
+    if (data && data.status && data.status !== 0) {
+        return handleError(
+            (err) => callback(err, data),
+            S2SErrorReason.REQUEST_FAILED_ON_SERVER,
+            data.message,
+            response,
+        );
     }
 
     return callback(null, data);

--- a/lib/pxhttpc.js
+++ b/lib/pxhttpc.js
@@ -17,7 +17,7 @@ module.exports = {
  * @param {string} callType - indication for a query or activities sending
  * @param {Function} callback - callback function.
  */
-function callServer(data, headers, uri, callType, config, callback) {
+function callServer(data, headers, uri, callType, config, callback, failOnEmptyBody = true) {
     callback =
         callback ||
         ((err) => {
@@ -56,7 +56,7 @@ function callServer(data, headers, uri, callType, config, callback) {
             }
 
             if (response.statusCode === 200) {
-                return handleOkResponse(callback, response);
+                return handleOkResponse(callback, response, failOnEmptyBody);
             }
 
             return handleUnexpectedHttpResponse(callback, response);
@@ -67,10 +67,10 @@ function callServer(data, headers, uri, callType, config, callback) {
     }
 }
 
-const handleOkResponse = (callback, response) => {
+const handleOkResponse = (callback, response, failOnEmptyBody) => {
     let data = getDataFromResponse(response);
 
-    if (!data && response.statusCode >= 300) {
+    if (!data && failOnEmptyBody) {
         return handleError(
             callback,
             S2SErrorReason.INVALID_RESPONSE,


### PR DESCRIPTION
* Fixes uneeded and wrong error message showing in debug for async activities:
```Dec 7, 09:37:21 AM: 01HH2BCD info   [human-enforcer] [PerimeterX - DEBUG][PX1yz6W67d] - callServer default callback. Error: {"errorReason":"invalid_response","errorMessage":"unable to get data from response body: ","httpStatus":200,"httpMessage":"OK"}```
* if the status is 200, even in the body is empty (content-length: 0), it shouldnt show this message